### PR TITLE
Use table for pause screen and fix bug #40

### DIFF
--- a/core/src/com/pqbyte/coherence/Coherence.java
+++ b/core/src/com/pqbyte/coherence/Coherence.java
@@ -1,6 +1,8 @@
 package com.pqbyte.coherence;
 
 import com.badlogic.gdx.Game;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
@@ -9,6 +11,7 @@ public class Coherence extends Game {
   public SpriteBatch batch;
   public BitmapFont font;
   private Screen previousScreen;
+  private InputProcessor previousInputProcessor;
 
   @Override
   public void create() {
@@ -26,8 +29,10 @@ public class Coherence extends Game {
   @Override
   public void pause() {
     previousScreen = getScreen();
+    previousInputProcessor = Gdx.input.getInputProcessor();
   }
 
+  @Override
   public void resume() {
     if (previousScreen instanceof GameScreen) {
       setScreen(new PauseScreen(this));
@@ -36,6 +41,10 @@ public class Coherence extends Game {
 
   public Screen getPreviousScreen() {
     return previousScreen;
+  }
+
+  public InputProcessor getPreviousInputProcessor() {
+    return previousInputProcessor;
   }
 }
 

--- a/core/src/com/pqbyte/coherence/PauseScreen.java
+++ b/core/src/com/pqbyte/coherence/PauseScreen.java
@@ -2,6 +2,7 @@ package com.pqbyte.coherence;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
+import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.graphics.GL20;
@@ -14,6 +15,7 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Button;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
 import com.badlogic.gdx.scenes.scene2d.ui.TextButton;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 
@@ -22,15 +24,26 @@ public class PauseScreen extends ScreenAdapter {
   private Stage stage;
   private Coherence game;
 
+  /**
+   * The screen that comes up when game is paused.
+   *
+   * @param game The game instance.
+   */
   public PauseScreen(Coherence game) {
     this.game = game;
     Skin skin = new Skin(Gdx.files.internal("skin/uiskin.json"));
-    Button button = createButton(skin);
-    Label titleLabel = createTitleLabel(skin);
-
     stage = new Stage();
-    stage.addActor(button);
-    stage.addActor(titleLabel);
+    Table table = new Table();
+    table.setFillParent(true);
+    stage.addActor(table);
+
+    Label titleLabel = createTitleLabel(skin);
+    table.add(titleLabel).spaceBottom(160);
+    table.row();
+    Button button = createButton(skin);
+    table.add(button).width(300).height(60);
+
+    table.setDebug(Constants.isDebug());
 
     Gdx.input.setInputProcessor(stage);
   }
@@ -40,6 +53,7 @@ public class PauseScreen extends ScreenAdapter {
     Gdx.gl.glClearColor(0, 0, 0, 1);
     Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
 
+    stage.act(delta);
     stage.draw();
   }
 
@@ -55,31 +69,11 @@ public class PauseScreen extends ScreenAdapter {
     label.setSize(label.getWidth() * 2, label.getHeight());
     label.setFontScale(2);
 
-    int width = Gdx.graphics.getWidth();
-    int height = Gdx.graphics.getHeight();
-
-    label.setPosition(
-        (width - label.getWidth()) / 2,
-        (height - label.getHeight()) / 2 + height / 4
-    );
-
     return label;
   }
 
   private Button createButton(Skin skin) {
     TextButton button = new TextButton("RESUME GAME", skin, "default");
-    int buttonWidth = 300;
-    int buttonHeight = 60;
-    button.setWidth(buttonWidth);
-    button.setHeight(buttonHeight);
-
-    int width = Gdx.graphics.getWidth();
-    int height = Gdx.graphics.getHeight();
-
-    button.setPosition(
-        (width - buttonWidth) / 2,
-        (height - buttonHeight) / 2 - height / 4
-    );
 
     button.addListener(new ClickListener() {
       @Override

--- a/core/src/com/pqbyte/coherence/PauseScreen.java
+++ b/core/src/com/pqbyte/coherence/PauseScreen.java
@@ -79,6 +79,7 @@ public class PauseScreen extends ScreenAdapter {
       @Override
       public void clicked(InputEvent event, float xPos, float yPos) {
         game.setScreen(game.getPreviousScreen());
+        Gdx.input.setInputProcessor(game.getPreviousInputProcessor());
         dispose();
       }
     });


### PR DESCRIPTION
The problem was that using setInputProcessor for the button in pause menu removed the input processor for the GameScreen. The fix was done by remembering the previous input processor and resetting it after pressing the resume button.
