### PR TITLE
Fix bug with new music instance starting over another

### DIFF
--- a/core/src/com/pqbyte/coherence/GameScreen.java
+++ b/core/src/com/pqbyte/coherence/GameScreen.java
@@ -178,6 +178,7 @@ public class GameScreen extends ScreenAdapter {
 
     if (alivePeople.size == 1) {
       game.setScreen(new WinnerScreen(game, alivePeople.first()));
+      dispose();
     }
   }
 


### PR DESCRIPTION
Previous screen was not disposed.
